### PR TITLE
 Tamu email id and Link validation added

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -87,7 +87,7 @@ main {
 .form{
     font-family: sans-serif;
     font-size: 16px;
-    max-width: 500px;
+    max-width: 40%;
     margin: 2rem auto;
     border:2px solid #500000;
     padding: 2rem;
@@ -101,10 +101,12 @@ main {
 .form__items{
     display: flex;
     flex-direction: column; 
+    width: 100%;
 }
 
 .form__items > * {
     align-self: flex-start;
+    
 }
 
 .form__lable {
@@ -112,6 +114,7 @@ main {
     font-weight: 540;
     padding: 1rem 0 .15rem;
     font-size: 20px;
+    max-width: 100%;
 }
 
 .form__input {
@@ -119,6 +122,7 @@ main {
     box-sizing: border-box;
     border: 0.25ch;
     font-size: 20px;
+    max-width: 100%;
 
 }
 

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -1,7 +1,14 @@
 class Student < ApplicationRecord
     validates :name, presence: true, format: { with: /([\w\-\']{2,})([\s]+)([\w\-\']{2,})/ }
-    validates :email_id, presence: true
     validates :uin, presence: true, length: { is: 9 }, format: { with: /\A[0-9]*\z/ }
     :attr_accessor
     has_many :subjects
+
+    email_regex = /\A[\w+\-.]+@tamu\.edu\z/i
+    validates :email_id, :presence => true,
+                  :format   => { :with => email_regex },
+                  :uniqueness => { :case_sensitive => false }
+
+    validates :resume, :presence => true, format: URI::DEFAULT_PARSER.make_regexp(%w[http https])
+    validates :transcript, :presence => true, format: URI::DEFAULT_PARSER.make_regexp(%w[http https])
 end


### PR DESCRIPTION
@tamu.edu specific email ID check and Resume/transcript link validation added. 
These fields can't be blank and should be in specific format. 

![image](https://user-images.githubusercontent.com/113077278/206329210-ca253006-677e-4a9b-996d-9ab38607d8f3.png)
